### PR TITLE
Fixed leaf child detection

### DIFF
--- a/javascripts/dataConverter.js
+++ b/javascripts/dataConverter.js
@@ -85,13 +85,14 @@ var convertFromWcToJSON = function(data) {
  */
 var getChildren = function(json) {
   var children = [];
-  if (json.language) return children;
+  if (json.isleaf) return children;
   for (var key in json) {
     var child = { name: key };
     if (json[key].size) {
       // value node
       child.size = json[key].size;
       child.language = json[key].language;
+      child.isleaf = true;
     } else {
       // children node
       var childChildren = getChildren(json[key]);


### PR DESCRIPTION
- Fixed leaf child detection when source tree has a directory named 'language', by adding a boolean instead of checking for 'language' value.
- Without this fix repos with a directory named 'language' won't render properly.
- An example is the [wikipedia android app repo](https://github.com/wikimedia/apps-android-wikipedia).
- It renders fine after this fix. See [here](https://deepankarb.github.io/CodeFlower/).

